### PR TITLE
Add Rectangle to Square conversion iterator

### DIFF
--- a/WorldRestoration/src/main/java/as/minecraft/geometry/Point.java
+++ b/WorldRestoration/src/main/java/as/minecraft/geometry/Point.java
@@ -11,4 +11,8 @@ public class Point {
 	public Point clone() {
 		return new Point(x, y);
 	}
+	
+	boolean equals(Point other) {
+		return x == other.x && y == other.y;
+	}
 }

--- a/WorldRestoration/src/main/java/as/minecraft/geometry/Square.java
+++ b/WorldRestoration/src/main/java/as/minecraft/geometry/Square.java
@@ -17,4 +17,8 @@ public class Square {
 				new Point(this.minPoint.x, this.minPoint.y),
 				new Point(this.minPoint.x + size, this.minPoint.y + size));
 	}
+	
+	boolean equals(Square other) {
+		return minPoint.equals(other.minPoint) && size == other.size;
+	}
 }

--- a/WorldRestoration/src/main/java/as/minecraft/worldrestoration/tasks/PerformRegen.java
+++ b/WorldRestoration/src/main/java/as/minecraft/worldrestoration/tasks/PerformRegen.java
@@ -38,8 +38,7 @@ public class PerformRegen implements Runnable{
 				List<Rectangle> rollbackRectangles = worldRectangle.subtractRectangles(claimRectangles);
 				
 				for(Rectangle rectangle: rollbackRectangles) {
-					List<Square> rollbackSquares = rectangle.convertToSquares();
-					for(Square square: rollbackSquares) {
+					for(Square square: rectangle.getSquaresIterable()) {
 						
 						Location squareCentre = new Location(world, (double) (square.minPoint.x) + (double)(square.size)/2.0, 62.0, (double) (square.minPoint.y) + (double)(square.size)/2.0);
 						int squareRadius = (int) (Math.ceil((double)(square.size) / 2.0));

--- a/WorldRestoration/src/test/java/as/minecraft/geometry/RectangleTest.java
+++ b/WorldRestoration/src/test/java/as/minecraft/geometry/RectangleTest.java
@@ -4,7 +4,8 @@ import static as.minecraft.geometry.RectangleTestUtils.assertAreaEquals;
 import static as.minecraft.geometry.RectangleTestUtils.assertInside;
 import static as.minecraft.geometry.RectangleTestUtils.assertInsideSquares;
 import static as.minecraft.geometry.RectangleTestUtils.assertNoOverlap;
-import static as.minecraft.geometry.RectangleTestUtils.assertNoOverlapSquares;
+import static as.minecraft.geometry.RectangleTestUtils.assertNoOverlapSquaresList;
+import static as.minecraft.geometry.RectangleTestUtils.assertNoOverlapSquaresIterable;
 import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
@@ -621,8 +622,13 @@ public class RectangleTest {
 		List<Square> squares = rectangle.convertToSquares();
 		
 		assertInsideSquares(squares, rectangle);
-		assertNoOverlapSquares(squares);
+		assertNoOverlapSquaresList(squares);
 		assertAreaEquals(rectangle, squares);
+		
+		Iterable<Square> squareIterable = rectangle.getSquaresIterable();
+		assertInsideSquares(squareIterable, rectangle);
+		assertNoOverlapSquaresIterable(squareIterable);
+		assertAreaEquals(rectangle, squareIterable);
 	}
 	
 	@Test

--- a/WorldRestoration/src/test/java/as/minecraft/geometry/RectangleTestUtils.java
+++ b/WorldRestoration/src/test/java/as/minecraft/geometry/RectangleTestUtils.java
@@ -8,7 +8,7 @@ import java.util.List;
 import java.util.Optional;
 
 public class RectangleTestUtils {
-	public static void assertInside(List<Rectangle> rectangles, Rectangle container) {
+	public static void assertInside(Iterable<Rectangle> rectangles, Rectangle container) {
 		for(Rectangle rect : rectangles) {
 			assertTrue(rect.minCoordinate.x >= container.minCoordinate.x);
 			assertTrue(rect.minCoordinate.y >= container.minCoordinate.y);
@@ -17,7 +17,7 @@ public class RectangleTestUtils {
 		}
 	}
 	
-	public static void assertInsideSquares(List<Square> squares, Rectangle container) {
+	public static void assertInsideSquares(Iterable<Square> squares, Rectangle container) {
 		for(Square square : squares) {
 			Rectangle rect = square.toRectangle();
 			assertTrue(rect.minCoordinate.x >= container.minCoordinate.x);
@@ -27,7 +27,7 @@ public class RectangleTestUtils {
 		}
 	}
 	
-	public static void assertNoOverlap(List<Rectangle> rectangles) {
+	public static void assertNoOverlap(Iterable<Rectangle> rectangles) {
 		for(Rectangle firstRect : rectangles) {
 			for (Rectangle secondRect : rectangles) {
 				if(firstRect != secondRect) {
@@ -37,10 +37,20 @@ public class RectangleTestUtils {
 		}
 	}
 	
-	public static void assertNoOverlapSquares(List<Square> squares) {
+	public static void assertNoOverlapSquaresList(List<Square> squares) {
 		for(Square firstSquare : squares) {
 			for (Square secondSquare : squares) {
 				if(firstSquare != secondSquare) {
+					assertNoOverlap(firstSquare.toRectangle(), secondSquare.toRectangle());
+				}
+			}
+		}
+	}
+	
+	public static void assertNoOverlapSquaresIterable(Iterable<Square> squares) {
+		for(Square firstSquare : squares) {
+			for (Square secondSquare : squares) {
+				if(!firstSquare.equals(secondSquare)) {
 					assertNoOverlap(firstSquare.toRectangle(), secondSquare.toRectangle());
 				}
 			}
@@ -73,7 +83,7 @@ public class RectangleTestUtils {
 	
 	public static void assertAreaEquals(
 			Rectangle baseRect,
-			List<Rectangle> subRectangles,
+			Iterable<Rectangle> subRectangles,
 			Optional<Rectangle> overlapRectangle) {
 		int areaSum = 0;
 		for(Rectangle subRectangle : subRectangles) {
@@ -86,7 +96,7 @@ public class RectangleTestUtils {
 	
 	public static void assertAreaEquals(
 			Rectangle baseRect,
-			List<Square> squares) {
+			Iterable<Square> squares) {
 		int areaSum = 0;
 		for(Square subRectangle : squares) {
 			areaSum += subRectangle.area();
@@ -98,8 +108,8 @@ public class RectangleTestUtils {
 
 	public static void assertAreaEquals(
 			Rectangle baseRectangle,
-			List<Rectangle> newRects,
-			List<Rectangle> overlapRegions) {
+			Iterable<Rectangle> newRects,
+			Iterable<Rectangle> overlapRegions) {
 		int areaSum = 0;
 		for (Rectangle rectangle : newRects) {
 			areaSum += rectangle.area();


### PR DESCRIPTION
The previously used Rectangle.convertToSquares method was expected to
consume huge amounts of memory. With the iterator technique, the memory
footprint is expected to be reduced significantly.